### PR TITLE
Added ability to update any property of the task like "callbackAfterSeconds"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-client",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Conductor client for nodejs ",
   "main": "./build/index.js",
   "scripts": {
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "axios": "0.18.0",
+    "lodash": "^4.17.11",
     "nanotimer": "^0.3.15"
   },
   "keywords": [

--- a/src/helper/watcher.js
+++ b/src/helper/watcher.js
@@ -1,5 +1,6 @@
 import os from 'os'
 import { pollForTask, ackTask, updateTask } from './connector'
+import { assign } from 'lodash'
 
 const DEFAULT_OPTIONS = {
   pollingIntervals: 1000,
@@ -42,19 +43,22 @@ export default class Watcher {
     taskId,
     reasonForIncompletion,
     status,
-    outputData = {}
+    outputData = {},
+    extraTaskData = {}
   }) => {
     if ([TASK_STATUS.FAILED, TASK_STATUS.COMPLETED].includes(status)) {
       this.destroyTaskTimeout(taskId)
       this.destroyTask(taskId)
     }
-    return updateTask(this.options.baseURL, {
+
+    return updateTask(this.options.baseURL, assign({
       workflowInstanceId,
       taskId,
       reasonForIncompletion,
       status,
-      outputData
-    })
+      outputData},
+      extraTaskData)
+    )
   }
 
   // this should be private function
@@ -75,14 +79,15 @@ export default class Watcher {
             }, data.responseTimeoutSeconds * 1000)
           }
           try {
-            await this.callback(data, ({ status, outputData, reasonForIncompletion = '' }) =>
+            await this.callback(data, ({ status, outputData, reasonForIncompletion = '',  extraTaskData = {}}) =>
               // This make life more easier
               this.updateResult({
                 workflowInstanceId: data.workflowInstanceId,
                 taskId: data.taskId,
                 reasonForIncompletion,
                 status,
-                outputData
+                outputData,
+                extraTaskData
               })
             )
           } catch (error) {
@@ -90,7 +95,8 @@ export default class Watcher {
               workflowInstanceId: data.workflowInstanceId,
               taskId: data.taskId,
               reasonForIncompletion: error.message,
-              status: TASK_STATUS.FAILED
+              status: TASK_STATUS.FAILED,
+              extraTaskData
             })
           }
         }


### PR DESCRIPTION
I needed to set "callbackAfterSeconds" on the task.  I did this by allowing an object "extraTaskData" to be passed into the callback like: 

`updater({ status: 'IN_PROGRESS', outputData: { someData:42}, extraTaskData:{callbackAfterSeconds:5} });`

This extraTaskData object will get overlayed into the the taskBody sent to the connector.updateTask() function. 